### PR TITLE
Fix table display in show_plot.html

### DIFF
--- a/templates/parse_file.html
+++ b/templates/parse_file.html
@@ -9,6 +9,19 @@
 {{ super() }}
 <script>
 $(document).ready(function(){
+    if($('#username').val() == ''){
+        $('#submit_button').attr('disabled','disabled');
+    }
+
+    $('#username').change(function(){
+        if($(this).val() != ''){
+            $('#submit_button').removeAttr('disabled');
+        }
+        else{
+            $('#submit_button').attr('disabled','disabled');
+        }
+    });
+
     $(".units").on('input', function(){
         var units = $(this).val();
         var input_id = $(this)[0].id;
@@ -39,7 +52,7 @@ $(document).ready(function(){
             <table class="table table-striped">
                 <thead><tr><th>File Column Name</th><th>Real Column Name</th><th>Units</th></tr></thead>
                 <tbody>
-                <tr><td>  <input type="checkbox" name="issimulated" value="IsSimulated">Is simulated? </td></tr>
+                <tr><td>  <input type="checkbox" name="issimulated" value="IsSimulated"> Is this simulated data? </td></tr>
                 <tr><td>  <input type="text" id="username" name="Username" value="" required></td> <td>Username? </td></tr>
                 
                 {% for column_name,best_column_name in zip(table.colnames, best_column_names) %}

--- a/templates/show_plot.html
+++ b/templates/show_plot.html
@@ -23,7 +23,7 @@ imagename = {{imagename}}
 
 <script> 
 $(function(){
-        $("#includedContent").load("/static/jstables/{{tablefile}}"); 
+        $("#includedContent").load("/static/jstables/{{tablefile}}?" + (new Date).getTime()); 
 });
 </script> 
 

--- a/upload_form.py
+++ b/upload_form.py
@@ -152,7 +152,6 @@ def handle_ambiguous_table(filename, exception):
     else:
         best_match = ""
 
-    # This doesn't work right now - don't know why.
     return render_template('upload_form_filetype.html', filename=filename,
                            best_match_extension=best_match,
                            exception=exception)


### PR DESCRIPTION
Previously, the browser would often cache the table shown on show_plot.html, meaning that the data in it could be stale. Therefore, we should force the browser to load the latest version of the table.
