### PR TITLE
Create and use unique names for uploaded files

### DIFF
--- a/upload_form.py
+++ b/upload_form.py
@@ -255,7 +255,6 @@ def set_columns(filename, fileformat=None):
     table = fix_bad_types(table)
     convert_units(table)
     add_name_column(table, column_data.get('Username')['Name'])
-    add_filename_column(table, filename)
     timestamp = datetime.now()
     add_timestamp_column(table, timestamp)
 
@@ -269,6 +268,14 @@ def set_columns(filename, fileformat=None):
         add_is_gal_if_needed(table, False)
     else:
         add_is_gal_if_needed(table, True)
+
+    # Rename the uploaded file to something unique, and store this name in the table
+    extension = os.path.splitext(filename)[-1]
+    file = open(os.path.join(app.config['UPLOAD_FOLDER'], filename)
+    unique_filename = hashlib.sha1(file.read()).hexdigest()[0:32] + extension
+    file.close() 
+    print(unique_filename)
+    add_filename_column(table, filename)
 
     # Detect duplicate IDs in uploaded data and bail out if found
     seen = {}

--- a/upload_form.py
+++ b/upload_form.py
@@ -16,7 +16,6 @@ from __future__ import print_function
 import os
 import inspect
 import numpy as np
-import datetime
 import subprocess
 import requests
 import json
@@ -36,8 +35,6 @@ import glob
 import random
 import keyring
 import __builtin__
-import glob
-import random
 import time
 import datetime
 from datetime import datetime

--- a/upload_form.py
+++ b/upload_form.py
@@ -272,9 +272,8 @@ def set_columns(filename, fileformat=None):
     # Rename the uploaded file to something unique, and store this name in the table
     extension = os.path.splitext(filename)[-1]
     full_filename_old = os.path.join(app.config['UPLOAD_FOLDER'], filename)
-    file = open(full_filename_old)
-    unique_filename = hashlib.sha1(file.read()).hexdigest()[0:36-len(extension)] + extension
-    file.close() 
+    with open(full_filename_old) as file:
+        unique_filename = hashlib.sha1(file.read()).hexdigest()[0:36-len(extension)] + extension
     full_filename_new = os.path.join(app.config['UPLOAD_FOLDER'], unique_filename)
     os.rename(full_filename_old, full_filename_new)
     add_filename_column(table, unique_filename)

--- a/upload_form.py
+++ b/upload_form.py
@@ -42,6 +42,7 @@ from astropy.io import registry, ascii
 from astropy.table import Table, vstack
 from astropy.table.jsviewer import write_table_jsviewer
 from astropy import units as u
+import hashlib
 
 UPLOAD_FOLDER = 'uploads/'
 DATABASE_FOLDER = 'database/'


### PR DESCRIPTION
This set of changes allows us to create unique names for the uploaded files, and to store these names in the database. Since this directly affects what we're storing in the database, it would be good if @keflavich  could review this before merging it, in case I've done something stupid.
