### PR TITLE
Add ADS ID and DOI to web form and parser

### DIFF
--- a/templates/parse_file.html
+++ b/templates/parse_file.html
@@ -79,6 +79,10 @@ $(document).ready(function(){
                 <tr><td colspan=3 class="middle"> <font color="#BDBDBD">(for simulations, choose Galactic unless an entire galaxy is covered)</font> </td></tr>
                 <tr><td colspan=3 class="middle">  <input type="text" id="username" name="Username" value="" required> FirstnameLastname of first author </td></tr>
                 <tr><td colspan=3 class="middle">  <input type="text" id="email" name="Email" value="" required> Your email address <font color="#BDBDBD">(this will be kept private)</font> </td></tr>
+                <tr><td colspan=3 class="middle">  <input type="text" id="adsid" name="adsid" value=""> ADS ID  </td></tr>
+                <tr><td colspan=3 class="middle">  <input type="text" id="doi" name="doi" value="" required> <a href="http://www.doi.org/">DOI: a permanent data link</a> 
+                        or URL <font color="#BDBDBD">(if this is over 64 characters, please <a href="http://tinyurl.com">shorten</a> it
+                            with a <a href="http://goo.gl/">url-shortener service</a>)</font></td></tr>
                 </tbody>
             </table>
             <div class="col-md-2 col-md-offset-10" id="column_submit">

--- a/upload_form.py
+++ b/upload_form.py
@@ -55,7 +55,7 @@ valid_column_names = ['Ignore', 'IDs', 'SurfaceDensity', 'VelocityDispersion',
                       'Radius', 'IsSimulated', 'IsGalactic', 'Username', 'Filename']
 dimensionless_column_names = ['Ignore', 'IDs', 'IsSimulated', 'IsGalactic',
                               'Username', 'Filename', 'Email', 'ObsSim',
-                              'GalExgal']
+                              'GalExgal', "ADS_ID", "DOI_or_URL"]
 use_column_names = ['SurfaceDensity', 'VelocityDispersion','Radius']
 use_units = ['Msun/pc^2','km/s','pc']
 FigureStrBase='Output_Sigma_sigma_r_'
@@ -64,7 +64,7 @@ TooOld=300 # age in seconds of files to delete
 git_user = 'SirArthurTheSubmitter'
 submitter_gmail = '{0}@gmail.com'.format(git_user)
 
-table_widths = [64, 64, 20, 20, 20, 12, 12, 26, 36]
+table_widths = [64, 64, 20, 20, 20, 12, 12, 26, 36, 20, 64]
 
 table_formats = registry.get_formats(Table)
 
@@ -262,6 +262,8 @@ def set_columns(filename, fileformat=None):
     table = fix_bad_types(table)
     convert_units(table)
     add_name_column(table, column_data.get('Username')['Name'])
+    tbl.add_column(table.Column(name='ADS_ID', data=[request.form['adsid']]*len(tbl)))
+    tbl.add_column(table.Column(name='DOI_or_URL', data=[request.form['doi']]*len(tbl)))
     timestamp = datetime.now()
     add_timestamp_column(table, timestamp)
 
@@ -285,7 +287,7 @@ def set_columns(filename, fileformat=None):
     os.rename(full_filename_old, full_filename_new)
     add_filename_column(table, unique_filename)
 
-    handle_email(column_data.get('Email')['Name'], unique_filename)
+    handle_email(request.form['Email'], unique_filename)
 
     # Detect duplicate IDs in uploaded data and bail out if found
     seen = {}

--- a/upload_form.py
+++ b/upload_form.py
@@ -55,7 +55,7 @@ valid_column_names = ['Ignore', 'IDs', 'SurfaceDensity', 'VelocityDispersion',
                       'Radius', 'IsSimulated', 'IsGalactic', 'Username', 'Filename']
 dimensionless_column_names = ['Ignore', 'IDs', 'IsSimulated', 'IsGalactic',
                               'Username', 'Filename', 'Email', 'ObsSim',
-                              'GalExgal', "ADS_ID", "DOI_or_URL"]
+                              'GalExgal', "ADS_ID", "DOI_or_URL", 'doi', 'adsid']
 use_column_names = ['SurfaceDensity', 'VelocityDispersion','Radius']
 use_units = ['Msun/pc^2','km/s','pc']
 FigureStrBase='Output_Sigma_sigma_r_'
@@ -262,8 +262,8 @@ def set_columns(filename, fileformat=None):
     table = fix_bad_types(table)
     convert_units(table)
     add_name_column(table, column_data.get('Username')['Name'])
-    tbl.add_column(table.Column(name='ADS_ID', data=[request.form['adsid']]*len(tbl)))
-    tbl.add_column(table.Column(name='DOI_or_URL', data=[request.form['doi']]*len(tbl)))
+    table.add_column(table.Column(name='ADS_ID', data=[request.form['adsid']]*len(table)))
+    table.add_column(table.Column(name='DOI_or_URL', data=[request.form['doi']]*len(table)))
     timestamp = datetime.now()
     add_timestamp_column(table, timestamp)
 

--- a/upload_form.py
+++ b/upload_form.py
@@ -329,6 +329,14 @@ def set_columns(filename, fileformat=None):
             # If we don't know the filename, flag it as unknown
             add_filename_column(merged_table, 'Unknown'+' '*29)
 
+        if 'ADS_ID' not in merged_table.colnames:
+            # If we don't know the filename, flag it as unknown
+            merged_table.add_column(table.Column(name='ADS_ID', data=['Unknown'+' '*13]*len(merged_table)))
+
+        if 'DOI_or_URL' not in merged_table.colnames:
+            # If we don't know the filename, flag it as unknown
+            merged_table.add_column(table.Column(name='DOI_or_URL', data=['Unknown'+' '*57]*len(merged_table)))
+
     else:
         # Maximum string length of 64 for username, ID -- larger strings are silently truncated
         # TODO: Adjust these numbers to something more reasonable, once we figure out what that is,


### PR DESCRIPTION
These are both required parameters, though an empty ADS ID is acceptable as
long as there is a DOI in place.  It would be good if we could either
automatically look up DOIs for ADS IDs (which is possible with the ADS API)
or at least provide instructions on how to get them.

arXiv papers on ADS don't have DOIs yet.
