### PR TITLE
Bad path to table?

### DIFF
--- a/upload_form.py
+++ b/upload_form.py
@@ -803,9 +803,8 @@ def query(filename, fileformat=None):
                           )
 
 @app.route('/query/static/jstables/<path:path>')
-@app.route('/static/jstables/<path:path>')
 def send_js(path):
-    return send_from_directory('/static/jstables/', path)
+    return send_from_directory('static/jstables/', path)
 
 @app.before_first_request
 def setup_authenticate_with_github():


### PR DESCRIPTION
![screen shot 2015-05-30 at 11 20 27 pm](https://cloud.githubusercontent.com/assets/3255771/7900693/9cf1eed0-0723-11e5-8ac2-b9550964838d.png)

Here's what the path is: http://camelot-project.herokuapp.com/static/jstables/static/jstables/Output_Table_20150531052709429032.ipac?1433050031223

"static/jstables" is getting appended twice somewhere.
