### PR TITLE
Remove box around legend in mpl plot

### DIFF
--- a/simple_plot.py
+++ b/simple_plot.py
@@ -377,7 +377,8 @@ def plotData(NQuery, input_table, FigureStrBase, html_dir=None, png_dir=None,
     ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
 
     # Put a legend to the right of the current axis
-    legend = ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+    legend = ax.legend(loc='center left', bbox_to_anchor=(1, 0.5),
+                       handlelength=4)
     legend.draw_frame(False)
 
     figure.savefig(png_file, bbox_inches='tight', dpi=150)

--- a/simple_plot.py
+++ b/simple_plot.py
@@ -377,7 +377,8 @@ def plotData(NQuery, input_table, FigureStrBase, html_dir=None, png_dir=None,
     ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
 
     # Put a legend to the right of the current axis
-    ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+    legend = ax.legend(loc='center left', bbox_to_anchor=(1, 0.5))
+    legend.draw_frame(False)
 
     figure.savefig(png_file, bbox_inches='tight', dpi=150)
     # figure.savefig(FigureStrBase+NQuery+'.pdf',bbox_inches='tight',dpi=150)


### PR DESCRIPTION
The markers in the png output were overlapping with the box. I just removed the box so it's cleaner and looks slightly more like the html plot.
