### PR TITLE
Queries with no results should return informative errors

### DIFF
--- a/simple_plot.py
+++ b/simple_plot.py
@@ -168,6 +168,9 @@ def plotData(NQuery, input_table, FigureStrBase, html_dir=None, png_dir=None,
     # intersects the three subsets defined above
     Use = Use_x_ax & Use_y_ax & Use_z_ax
 
+    if np.count_nonzero(Use) == 0:
+        return None,None
+
     UniqueAuthor = list(set(Author[Use]))
     NUniqueAuthor = len(UniqueAuthor)
 

--- a/upload_form.py
+++ b/upload_form.py
@@ -800,6 +800,13 @@ def query(filename, fileformat=None):
                              html_dir=app.config['MPLD3_FOLDER'],
                              png_dir=app.config['PNG_PLOT_FOLDER'])
 
+    # It is possible to create an empty query
+    if myplot_html is None or myplot_png is None:
+        return render_template('error.html',
+                               error="No data were found matching your query.",
+                               traceback="",
+                              )
+
     return render_template('show_plot.html', imagename='/'+myplot_html,
                            png_imagename="/"+myplot_png,
                            tablefile=tablefile)


### PR DESCRIPTION
if there are no data in the query, return an error page instead of a generic
server error
