### PR TITLE
Units and other parameters from table units and metadata (when available)

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -16,9 +16,6 @@ h1{
 }	
 
 #upload_form{
-	margin-top: 140px;
-	padding-top: 24px;
-	margin-bottom: 87px;
 }
 
 #upload_header{
@@ -103,4 +100,8 @@ body {
 .red {
     color: #CC0000;
     font-weight: bold;
+}
+
+samp {
+    background-color: #f7f7f7;
 }

--- a/templates/parse_file.html
+++ b/templates/parse_file.html
@@ -51,7 +51,7 @@ $(document).ready(function(){
             <table class="table table-striped">
                 <thead><tr><th>File Column Name</th><th>Real Column Name</th><th><font color="red">*</font>Units</th></tr></thead>
                 <tbody>                
-                {% for column_name,best_column_name in zip(table.colnames, best_column_names) %}
+                {% for column_name,best_column_name,default_unit in zip(table.colnames, best_column_names, default_units) %}
                 <tr>
                     <div class="form-group">
                     <td class="middle"><p>{{ column_name }}</p></td>
@@ -67,7 +67,7 @@ $(document).ready(function(){
                         </select>
                     </td>
                     <td class="middle">
-                        <input class="units form-control" id="{{column_name|striptags}}_units" name="{{column_name|striptags}}_units">
+                        <input class="units form-control" id="{{column_name|striptags}}_units" name="{{column_name|striptags}}_units" value="{{default_unit}}">
                     </td>
                     </div>
                 </tr>
@@ -75,17 +75,17 @@ $(document).ready(function(){
                 </tbody>
                 <thead><tr><th colspan=3><font color="red">*</font>Type of dataset</th></tr></thead>
                 <tbody>
-                <tr><td class="middle">  <input type="radio" name="ObsSim" value="IsObserved"> Observations </td>
-                    <td colspan=2 class="middle"> <input type="radio" name="ObsSim" value="IsSimulated"> Simulations </td></tr>
-                <tr><td class="middle">  <input type="radio" name="GalExgal" value="IsGalactic"> Galactic </td>
-                    <td colspan=2 class="middle"> <input type="radio" name="GalExgal" value="IsExtragalactic"> Extragalactic </td></tr>
+                <tr><td class="middle">  <input type="radio" name="ObsSim" value="IsObserved"{% if tab_metadata['IsObserved'] %} checked{% endif %}> Observations </td>
+                    <td colspan=2 class="middle"> <input type="radio" name="ObsSim" value="IsSimulated"{% if tab_metadata['IsSimulated'] %} checked{% endif %}> Simulations </td></tr>
+                <tr><td class="middle">  <input type="radio" name="GalExgal" value="IsGalactic"{% if tab_metadata['IsGalactic'] %} checked{% endif %}> Galactic </td>
+                    <td colspan=2 class="middle"> <input type="radio" name="GalExgal" value="IsExtragalactic"{% if tab_metadata['IsExtragalactic'] %} checked{% endif %}> Extragalactic </td></tr>
                 <tr><td colspan=3 class="middle"> <font color="#BDBDBD">(for simulations, choose Galactic unless an entire galaxy is covered)</font> </td></tr>
-                <tr><td colspan=3 class="middle"> <input type="text" id="username" name="Username" value="" required> <font color="red">*</font>FirstnameLastname of first author </td></tr>
-                <tr><td colspan=3 class="middle"> <input type="text" id="adsid" name="adsid" value=""> <font color="red">*</font>ADS ID <font color="#BDBDBD">(not the full link)</font> or 
-                                                  <input type="text" id="doi" name="doi" value="" required> <a href="http://www.doi.org/">DOI</a> or URL</td></tr>
+                <tr><td colspan=3 class="middle"> <input type="text" id="username" name="Username" value="{{tab_metadata['Author']}}" required> <font color="red">*</font>FirstnameLastname of first author </td></tr>
+                <tr><td colspan=3 class="middle"> <input type="text" id="adsid" name="adsid" value="{{tab_metadata['ADS_ID']}}"> <font color="red">*</font>ADS ID <font color="#BDBDBD">(not the full link)</font> or
+                                                  <input type="text" id="doi" name="doi" value="{{tab_metadata['DOI or URL']}}" required> <a href="http://www.doi.org/">DOI</a> or URL</td></tr>
                 <tr><td colspan=3 class="middle"> <font color="#BDBDBD">(if this is over 64 characters, please <a href="http://tinyurl.com">shorten</a> it
                             with a <a href="http://goo.gl/">url-shortener service</a>)</font></td></tr>
-                <tr><td colspan=3 class="middle"> <input type="text" id="email" name="Email" value="" required> 
+                <tr><td colspan=3 class="middle"> <input type="text" id="email" name="Email" value="{{tab_metadata['Submitter']}}" required>
                         <font color="red">*</font>Your email address <font color="#BDBDBD">(this will be kept private)</font> </td></tr>
                 <tr><td colspan=3 class="middle"> <font color="red">*</font>required </td></tr>
                 </tbody>

--- a/templates/upload_form.html
+++ b/templates/upload_form.html
@@ -43,7 +43,7 @@ $(document).ready(function(){
         <br>
         <div>
             The file reader uses the 
-            <a href="astropy.readthedocs.org/en/latest/table/">astropy.table</a>
+            <a href="http://astropy.readthedocs.org/en/latest/table/">astropy.table</a>
             module, which accepts a variety of file formats (simple ascii,
             csv, IPAC, cds, FITS, etc...).
         </div>

--- a/templates/upload_form.html
+++ b/templates/upload_form.html
@@ -38,9 +38,18 @@ $(document).ready(function(){
 
 <h1 class="title">CAMELOT Upload form</h1>
 <div class="row">
-    <div class="col-md-6 col-md-offset-4" id="upload_form">
+    <div class="col-md-22 col-md-offset-1" id="upload_form">
         <div id="upload_header">Upload a new data table file</div>
-        <div> Later steps will have you specify the column units etc. </div>
+        <br>
+        <div> The file reader uses the astropy.table module and a variety of file formats are accepted
+              (simple ascii, csv, IPAC tables format, etc...). Four columns are required providing
+              IDs, SurfaceDensity, VelocityDispersion, and Radius. Units for the physical quantities
+              and metadata to identify the provider of the data are required and can be fully or
+              partially read from the table (if the chosen format supports them) or will be entered
+              manually in the next form. </div>
+        <div> An example of compatible IPAC table format with units and
+              metadata is shown below.</div>
+        <br>
         <form class="form form-inline" action="upload" method="post" enctype="multipart/form-data">
             <div class="form-group">
                 <div class="input-group">
@@ -50,6 +59,21 @@ $(document).ready(function(){
                 </div>    
             </div>
         </form>
+        <br>
+        <div>Example file in IPAC table format, with units and metadata (these are not mandatory in the file)</div>
+        <br>
+        <samp>\DOI = "10.1051/0004-6361/201014177"<br>
+              \ADS = "2010A&A...520A..50S"<br>
+              \author = GinaSantangelo<br>
+              \email = king.arthur@camelot-project.org<br>
+              \IsObserved = True<br>
+              \IsGalactic = True<br>
+              |  ID | Radius | SurfaceDensity | VelocityDispersion |<br>
+              |char | float  | float          | float              |<br>
+              |     |  pc    |  g/cm^2        |  km/s              |<br>
+                co1   3.0      0.10            7.3                 <br>
+                co2   4.1      0.08            5.5                 <br>
+                ...                 </samp>
     </div>
 </div>
 <div id='footer'></div>

--- a/templates/upload_form.html
+++ b/templates/upload_form.html
@@ -38,18 +38,36 @@ $(document).ready(function(){
 
 <h1 class="title">CAMELOT Upload form</h1>
 <div class="row">
-    <div class="col-md-22 col-md-offset-1" id="upload_form">
+    <div class="" id="upload_form">
         <div id="upload_header">Upload a new data table file</div>
         <br>
-        <div> The file reader uses the astropy.table module and a variety of file formats are accepted
-              (simple ascii, csv, IPAC tables format, etc...). Four columns are required providing
-              IDs, SurfaceDensity, VelocityDispersion, and Radius. Units for the physical quantities
+        <div>
+            The file reader uses the 
+            <a href="astropy.readthedocs.org/en/latest/table/">astropy.table</a>
+            module, which accepts a variety of file formats (simple ascii,
+            csv, IPAC, cds, FITS, etc...).
+        </div>
+        <br><div> Four columns are required:
+            <ul>
+                <li> Object IDs (<tt>IDs</tt>)
+                <li> Surface Density (<tt>SurfaceDensity</tt>)
+                <li> Velocity Dispersion (<tt>VelocityDispersion</tt>)
+                <li> Radius (</tt>Radius</tt>)
+            </ul>
+          </div>
+          <br>
+          <div>Units for the physical quantities
               and metadata to identify the provider of the data are required and can be fully or
-              partially read from the table (if the chosen format supports them) or will be entered
-              manually in the next form. </div>
-        <div> An example of compatible IPAC table format with units and
-              metadata is shown below.</div>
+              partially read from the table if the chosen format supports them.
+              If not, you will be be prompted to enter them manually in the
+              next form.
+          </div>
+          <br>
+          <div> 
+            An example IPAC table with units and metadata is shown below.
+         </div>
         <br>
+        <center>
         <form class="form form-inline" action="upload" method="post" enctype="multipart/form-data">
             <div class="form-group">
                 <div class="input-group">
@@ -59,21 +77,23 @@ $(document).ready(function(){
                 </div>    
             </div>
         </form>
+        </center>
         <br>
-        <div>Example file in IPAC table format, with units and metadata (these are not mandatory in the file)</div>
+        <div>Example file in IPAC table format, with (optional) units and metadata</div>
         <br>
-        <samp>\DOI = "10.1051/0004-6361/201014177"<br>
-              \ADS = "2010A&A...520A..50S"<br>
-              \author = GinaSantangelo<br>
-              \email = king.arthur@camelot-project.org<br>
-              \IsObserved = True<br>
-              \IsGalactic = True<br>
-              |  ID | Radius | SurfaceDensity | VelocityDispersion |<br>
-              |char | float  | float          | float              |<br>
-              |     |  pc    |  g/cm^2        |  km/s              |<br>
-                co1   3.0      0.10            7.3                 <br>
-                co2   4.1      0.08            5.5                 <br>
-                ...                 </samp>
+        <pre style="width:600px; margin-left:auto; margin-right: auto; overflow:auto">
+\DOI = "10.1051/0004-6361/201014177"
+\ADS = "2010A\&A...520A..50S"
+\author = GinaSantangelo
+\email = king.arthur@camelot-project.org
+\IsObserved = True
+\IsGalactic = True
+|  ID | Radius | SurfaceDensity | VelocityDispersion |
+|char | float  | float          | float              |
+|     |  pc    |  g/cm^2        |  km/s              |
+ co1   3.0      0.10            7.3
+ co2   4.1      0.08            5.5
+... etc ... </pre>
     </div>
 </div>
 <div id='footer'></div>

--- a/upload_form.py
+++ b/upload_form.py
@@ -186,9 +186,34 @@ def uploaded_file(filename, fileformat=None):
     # column names can't have non-letters in them or javascript fails
     fix_bad_colnames(table)
 
+    column_units=[table[cln].unit for cln in table.colnames]
+    tab_metadata={'Author':'','ADS_ID':'','DOI or URL':'','Submitter':'',
+                  'IsObserved':False,'IsSimulated':False,
+                  'IsGalactic':False,'IsExtragalactic':False}
+    if len(table.meta) > 0:
+        for name, keyword in table.meta['keywords'].items():
+            if name.lower() == 'Author'.lower():
+                tab_metadata['Author']=keyword['value']
+            if (name.lower() == 'ADS_ID'.lower()) or (name.lower() == 'ADS'.lower()):
+                tab_metadata['ADS_ID']=keyword['value']
+            if (name.lower() == 'DOI'.lower()) or (name.lower() == 'URL'.lower()):
+                tab_metadata['DOI or URL']=keyword['value']
+            if (name.lower() == 'email'.lower()) or (name.lower() == 'submitter'.lower()):
+                tab_metadata['Submitter']=keyword['value']
+            if (name.lower() == 'IsObserved'.lower()):
+                tab_metadata['IsObserved']=keyword['value']
+            if (name.lower() == 'IsSimulated'.lower()):
+                tab_metadata['IsSimulated']=keyword['value']
+            if (name.lower() == 'IsExtragalactic'.lower()):
+                tab_metadata['IsExtragalactic']=keyword['value']
+            if (name.lower() == 'IsGalactic'.lower()):
+                tab_metadata['IsGalactic']=keyword['value']
+
     return render_template("parse_file.html", table=table, filename=filename,
                            real_column_names=valid_column_names,
                            best_column_names=best_column_names,
+                           default_units=column_units,
+                           tab_metadata=tab_metadata,
                            fileformat=fileformat,
                           )
 

--- a/upload_form.py
+++ b/upload_form.py
@@ -203,24 +203,6 @@ def uploaded_file(filename, fileformat=None):
                 outkey = mydict[name.lower()]
                 tab_metadata[outkey] = keyword['value']
 
-        # for name, keyword in table.meta['keywords'].items():
-        #     if name.lower() == 'Author'.lower():
-        #         tab_metadata['Author']=keyword['value']
-        #     if (name.lower() == 'ADS_ID'.lower()) or (name.lower() == 'ADS'.lower()):
-        #         tab_metadata['ADS_ID']=keyword['value']
-        #     if (name.lower() == 'DOI'.lower()) or (name.lower() == 'URL'.lower()):
-        #         tab_metadata['DOI or URL']=keyword['value']
-        #     if (name.lower() == 'email'.lower()) or (name.lower() == 'submitter'.lower()):
-        #         tab_metadata['Submitter']=keyword['value']
-        #     if (name.lower() == 'IsObserved'.lower()):
-        #         tab_metadata['IsObserved']=keyword['value']
-        #     if (name.lower() == 'IsSimulated'.lower()):
-        #         tab_metadata['IsSimulated']=keyword['value']
-        #     if (name.lower() == 'IsExtragalactic'.lower()):
-        #         tab_metadata['IsExtragalactic']=keyword['value']
-        #     if (name.lower() == 'IsGalactic'.lower()):
-        #         tab_metadata['IsGalactic']=keyword['value']
-
     return render_template("parse_file.html", table=table, filename=filename,
                            real_column_names=valid_column_names,
                            best_column_names=best_column_names,

--- a/upload_form.py
+++ b/upload_form.py
@@ -191,16 +191,16 @@ def uploaded_file(filename, fileformat=None):
     tab_metadata={'Author':'','ADS_ID':'','DOI or URL':'','Submitter':'',
                   'IsObserved':False,'IsSimulated':False,
                   'IsGalactic':False,'IsExtragalactic':False}
-    mydict = {'author': 'Author',
-              'ads': 'ADS_ID', 'asd_id': 'ADS_ID',
-              'doi': 'DOI or URL', 'url': 'DOI or URL',
-              'email': 'Submitter', 'submitter': 'Submitter',
-              'isobserved': 'IsObserved', 'issimulated': 'IsSimulated',
-              'isgalactic': 'IsGalactic', 'isextragalactic': 'IsExtragalactic'}
+    metadata_name_mapping = {'author': 'Author',
+                             'ads': 'ADS_ID', 'asd_id': 'ADS_ID',
+                             'doi': 'DOI or URL', 'url': 'DOI or URL',
+                             'email': 'Submitter', 'submitter': 'Submitter',
+                             'isobserved': 'IsObserved', 'issimulated': 'IsSimulated',
+                             'isgalactic': 'IsGalactic', 'isextragalactic': 'IsExtragalactic'}
     if len(table.meta) > 0:
         for name, keyword in table.meta['keywords'].items():
-            if name.lower() in mydict:
-                outkey = mydict[name.lower()]
+            if name.lower() in metadata_name_mapping:
+                outkey = metadata_name_mapping[name.lower()]
                 tab_metadata[outkey] = keyword['value']
 
     return render_template("parse_file.html", table=table, filename=filename,

--- a/upload_form.py
+++ b/upload_form.py
@@ -186,28 +186,40 @@ def uploaded_file(filename, fileformat=None):
     # column names can't have non-letters in them or javascript fails
     fix_bad_colnames(table)
 
+    # read units and keywords from table
     column_units=[table[cln].unit for cln in table.colnames]
     tab_metadata={'Author':'','ADS_ID':'','DOI or URL':'','Submitter':'',
                   'IsObserved':False,'IsSimulated':False,
                   'IsGalactic':False,'IsExtragalactic':False}
+    mydict = {'author': 'Author',
+              'ads': 'ADS_ID', 'asd_id': 'ADS_ID',
+              'doi': 'DOI or URL', 'url': 'DOI or URL',
+              'email': 'Submitter', 'submitter': 'Submitter',
+              'isobserved': 'IsObserved', 'issimulated': 'IsSimulated',
+              'isgalactic': 'IsGalactic', 'isextragalactic': 'IsExtragalactic'}
     if len(table.meta) > 0:
         for name, keyword in table.meta['keywords'].items():
-            if name.lower() == 'Author'.lower():
-                tab_metadata['Author']=keyword['value']
-            if (name.lower() == 'ADS_ID'.lower()) or (name.lower() == 'ADS'.lower()):
-                tab_metadata['ADS_ID']=keyword['value']
-            if (name.lower() == 'DOI'.lower()) or (name.lower() == 'URL'.lower()):
-                tab_metadata['DOI or URL']=keyword['value']
-            if (name.lower() == 'email'.lower()) or (name.lower() == 'submitter'.lower()):
-                tab_metadata['Submitter']=keyword['value']
-            if (name.lower() == 'IsObserved'.lower()):
-                tab_metadata['IsObserved']=keyword['value']
-            if (name.lower() == 'IsSimulated'.lower()):
-                tab_metadata['IsSimulated']=keyword['value']
-            if (name.lower() == 'IsExtragalactic'.lower()):
-                tab_metadata['IsExtragalactic']=keyword['value']
-            if (name.lower() == 'IsGalactic'.lower()):
-                tab_metadata['IsGalactic']=keyword['value']
+            if name.lower() in mydict:
+                outkey = mydict[name.lower()]
+                tab_metadata[outkey] = keyword['value']
+
+        # for name, keyword in table.meta['keywords'].items():
+        #     if name.lower() == 'Author'.lower():
+        #         tab_metadata['Author']=keyword['value']
+        #     if (name.lower() == 'ADS_ID'.lower()) or (name.lower() == 'ADS'.lower()):
+        #         tab_metadata['ADS_ID']=keyword['value']
+        #     if (name.lower() == 'DOI'.lower()) or (name.lower() == 'URL'.lower()):
+        #         tab_metadata['DOI or URL']=keyword['value']
+        #     if (name.lower() == 'email'.lower()) or (name.lower() == 'submitter'.lower()):
+        #         tab_metadata['Submitter']=keyword['value']
+        #     if (name.lower() == 'IsObserved'.lower()):
+        #         tab_metadata['IsObserved']=keyword['value']
+        #     if (name.lower() == 'IsSimulated'.lower()):
+        #         tab_metadata['IsSimulated']=keyword['value']
+        #     if (name.lower() == 'IsExtragalactic'.lower()):
+        #         tab_metadata['IsExtragalactic']=keyword['value']
+        #     if (name.lower() == 'IsGalactic'.lower()):
+        #         tab_metadata['IsGalactic']=keyword['value']
 
     return render_template("parse_file.html", table=table, filename=filename,
                            real_column_names=valid_column_names,


### PR DESCRIPTION
Recoded following the suggestion from Adam.
This has been tested with ipac tables. Should fill in the units and metadata that are found in the table (the user will still need to review and submit and/or fill in for missing units/metadata).
Example:

```
\DOI = "10.1051/0004-6361/201014177"
\ADS = "2010A&A...520A..50S"
\author = GinaSantangelo
\email = ltesti@eso.org
\IsObserved = True
\IsGalactic = True
|  ID | Radius | SurfaceDensity | VelocityDispersion |
|char | float  | float          | float              |
|     |  pc    |  g/cm^2        |  km/s              |
   co1   3.0      0.10            7.3                 
   co2   4.1      0.08            5.5                 
   co3   8.3      0.08            5.2                 
...
```
